### PR TITLE
Create initial configurations 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ override.tf.json
 # !example_override.tf
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
-# example: *tfplan*
+*tfplan*
 
 # Ignore CLI configuration files
 .terraformrc

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository contains Terraform configuration files for managing Tailscale ne
     ├── main.tf              # Main Tailscale resources
     ├── provider.tf          # Terraform provider configuration
     ├── variables.tf         # Variable definitions
-    ├── values.auto.tfvars   # Variable values (contains sensitive data)
+    ├── values.auto.tfvars   # Variable values (contains sensitive data, should not be committed to version control)
     └── terraform.tfstate    # Terraform state file
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,80 @@
-# tailscale
+# Tailscale Terraform Configuration
+
+This repository contains Terraform configuration files for managing Tailscale network settings using Infrastructure as Code (IaC). It provides automated setup and management of Tailscale ACLs, DNS preferences, and nameservers.
+
+## Overview
+
+[Tailscale](https://tailscale.com/) is a VPN service that creates secure networks between your devices. This Terraform configuration automates the management of:
+
+- **Access Control Lists (ACLs)**: Network access policies
+- **DNS Preferences**: MagicDNS configuration 
+- **DNS Nameservers**: Custom DNS server settings
+
+## Project Structure
+
+```sh
+.
+├── README.md
+└── terraform/
+    ├── main.tf              # Main Tailscale resources
+    ├── provider.tf          # Terraform provider configuration
+    ├── variables.tf         # Variable definitions
+    ├── values.auto.tfvars   # Variable values (contains sensitive data)
+    └── terraform.tfstate    # Terraform state file
+```
+
+## Prerequisites
+
+Before using this configuration, ensure you have:
+
+1. **Terraform** installed (version 0.12 or later)
+2. A **Tailscale account** with admin access
+3. A **Tailscale API key** with appropriate permissions
+
+## Usage
+
+### Initial Setup
+
+1. **Clone this repository**:
+   ```bash
+   git clone <repository-url>
+   cd tailscale
+   ```
+
+2. **Navigate to the terraform directory**:
+   ```bash
+   cd terraform
+   ```
+
+3. **Update the API key**:
+   Edit `values.auto.tfvars` and replace the API key with your own:
+   ```terraform
+   tailscale_api_key = "your-tailscale-api-key-here"
+   ```
+
+4. **Initialize Terraform**:
+   ```bash
+   terraform init
+   ```
+
+5. **Plan the deployment**:
+   ```bash
+   terraform plan
+   ```
+
+6. **Apply the configuration**:
+   ```bash
+   terraform apply
+   ```
+
+### Destroying Resources
+
+To remove all Tailscale configurations managed by this Terraform:
+
+```bash
+terraform destroy
+```
+
+## License
+
+This project is open source. Please check the LICENSE file for details.

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/tailscale/tailscale" {
+  version = "0.21.1"
+  hashes = [
+    "h1:jtRN8X5NWpfQgnuxKvGOKdTDqWmDRtgOF85AFwKi690=",
+    "zh:0ececf1715d6ece1983e773f8b8def68e8d2d455ff1e5d49fffa97a62c629661",
+    "zh:36146ceadff77791297dfdffe3fa39a6a93b8efc5f0cf55e64f8ad9143685bb5",
+    "zh:4e5304e0443fa6f99ac4c280c0d780078c09475c705581199e3dbd1c0b66fc51",
+    "zh:513cfda48dbcec49034984667c65dc8e534efa5a57e8904aa431bd99c65f45eb",
+    "zh:5dd4689231f430226abfb7ebe9762771e107c04fa7b18d76c1042a3ef6ae67dd",
+    "zh:603a9d8b556effa5d62a7d6777cb709b8563f5e5c263f5edfba6bc09ff896dab",
+    "zh:7c4a6749c9bfe368ab60aed8118fd302b5aa7a4b31c57cdc55d742bcff560309",
+    "zh:80d4f3d3172ba7031824e792bbe617b56a251c41c09fdb1a78404e8f1a272fbe",
+    "zh:85ca224be7e90be39886e5ce112b067fc93a01ce1d5de5e97875d64fa60c9271",
+    "zh:9c6593412663acafe569be1f324198dfebdc5799c0b144ff53c3c2c53a4277c4",
+    "zh:b62ca3483297fdc709288f9fe62cad9083daeefbd7ed6f2b36c8dace0511aabb",
+    "zh:b70b9554defc04c541e5a1f7304e540e2dd78c6a8afda92ade21a4a7c5dda236",
+    "zh:d45027054646da28b76922c18ad5581a6415e69dbbeb1af1d71a993f0d88a5a2",
+    "zh:d94dc6cbd25bba14cc2df3151e10029cbf9ad20dfbfbb69dba3fdc1e41d0ac5f",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,19 @@
+resource "tailscale_acl" "open" {
+  acl = jsonencode({
+    acls = [
+      {
+        action = "accept",
+        src    = ["*"],
+        dst    = ["*:*"]
+      }
+    ]
+  })
+}
+
+resource "tailscale_dns_preferences" "magic_dns" {
+  magic_dns = true
+}
+
+resource "tailscale_dns_nameservers" "public_dns" {
+  nameservers = ["1.1.1.1", "8.8.8.8"]
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    tailscale = {
+      source  = "tailscale/tailscale"
+    }
+  }
+}
+
+provider "tailscale" {
+  api_key = var.tailscale_api_key
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     tailscale = {
       source  = "tailscale/tailscale"
+      version = "0.21.1"
     }
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,5 @@
+variable "tailscale_api_key" {
+  description = "API key for Tailscale"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
This pull request introduces a Terraform-based setup for managing Tailscale network configurations. It includes updates to the project documentation, the addition of Terraform configuration files, and the implementation of Tailscale resources such as ACLs, DNS preferences, and nameservers.

### Documentation Updates:
* Updated `README.md` to provide an overview of the project, including its purpose, structure, prerequisites, and usage instructions for managing Tailscale configurations with Terraform.

### Terraform Configuration:
* Added `terraform/provider.tf` to define the required Tailscale provider and configure it using an API key.
* Added `terraform/variables.tf` to define a sensitive variable for the Tailscale API key.
* Added `terraform/main.tf` to define Tailscale resources:
  - ACLs with open access (`tailscale_acl`).
  - MagicDNS preferences (`tailscale_dns_preferences`).
  - Public DNS nameservers (`tailscale_dns_nameservers`).

### Dependency Management:
* Added `.terraform.lock.hcl` to lock the Tailscale provider version (`0.21.1`) and its associated hashes for consistent builds.